### PR TITLE
set and get of a Buffer do not match without this patch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Here are examples that demonstrate how to implement the Redis cache store.
 
 ```js
 var cacheManager = require('cache-manager');
-var redisStore = require('cache-manager-redis');
+var redisStore = require('cache-manager-store-redis');
 
 var redisCache = cacheManager.caching({
 	store: redisStore,
@@ -87,7 +87,7 @@ redisCache.wrap(key, function (cb) {
 
 ```js
 var cacheManager = require('cache-manager');
-var redisStore = require('cache-manager-redis');
+var redisStore = require('cache-manager-store-redis');
 
 var redisCache = cacheManager.caching({store: redisStore, db: 0, ttl: 600});
 var memoryCache = cacheManager.caching({store: 'memory', max: 100, ttl: 60});
@@ -146,4 +146,4 @@ If you would like to contribute to the project, please fork it and send us a pul
 License
 -------
 
-`node-cache-manager-redis` is licensed under the MIT license.
+`node-cache-manager-store-redis` is licensed under the MIT license.

--- a/index.js
+++ b/index.js
@@ -78,6 +78,15 @@ function redisStore(args) {
 
       if (opts.parse) {
         result = JSON.parse(result);
+        if(!result){
+          // return nothing
+        }
+        else if(result.isBuffer && result.value && result.value.type === 'Buffer' && result.value.data){
+          result = new Buffer(result.value.data);
+        }
+        else{
+          result = result.value;
+        }
       }
 
       if (cb) {
@@ -121,7 +130,10 @@ function redisStore(args) {
 
     var ttl = (options.ttl || options.ttl === 0) ? options.ttl : redisOptions.ttl;
 
-    var val = JSON.stringify(value);
+    var val = JSON.stringify({
+      value: value,
+      isBuffer: Buffer.isBuffer(value)
+    });
 
     if (ttl) {
       conn.setex(key, ttl, val, handleResponse(cb));

--- a/spec/lib/redis-store-spec.js
+++ b/spec/lib/redis-store-spec.js
@@ -65,6 +65,17 @@ describe('get', function () {
     });
   });
 
+  it('should property get a Buffer value', function (done) {
+    var value = new Buffer('bar');
+    redisCache.set('foo', value, function () {
+      redisCache.get('foo', function (err, result) {
+        expect(err).toBe(null);
+        expect(result).toEqual(value);
+        done();
+      });
+    });
+  });
+
   it('should retrieve a value for a given key if options provided', function (done) {
     var value = 'bar';
     redisCache.set('foo', value, function () {


### PR DESCRIPTION
With the memory cache, set/get of Buffer works fine.  This issue happens because JSON.stringify(new Buffer('bar'));  creates a JSON string like {type: "Buffer", data: [byte_array]}.

