### PR TITLE
Add option to pass in own client factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ redisCache.store.events.on('redisError', function(error) {
 	console.log(error);
 });
 
+// Pass in an existing node_redis compatible client
+var redisCache = cacheManager.caching({
+  store: redisStore,
+  createClient: function () {
+    return redis.createClient(...)
+  }
+});
+
 redisCache.set('foo', 'bar', ttl, function(err) {
     if (err) {
       throw err;


### PR DESCRIPTION
This adds support for passing in a client factory instead of connection details. This makes it possible to manage your own client, and use alternative clients such as ioredis.